### PR TITLE
Fix GitHub Actions workflow failures

### DIFF
--- a/.github/workflows/cronjob.yml
+++ b/.github/workflows/cronjob.yml
@@ -13,11 +13,11 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Start containers
       run: |
-        docker-compose -f "docker-compose.yaml" up --build
+        docker compose -f "docker-compose.yaml" up --build
 
     - uses: EndBug/add-and-commit@v9
       with:
@@ -26,6 +26,6 @@ jobs:
 
     - name: Stop containers
       if: always()
-      run: docker-compose -f "docker-compose.yaml" down
+      run: docker compose -f "docker-compose.yaml" down
 
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
     entrypoint: poetry run
-    command: python get_count.py
+    command: python src/get_count.py
     volumes:
     - ./data:/data
     environment:


### PR DESCRIPTION
## Summary
- Updates GitHub Actions workflow to resolve exit code 127 failures
- Fixes deprecated Node.js and Docker Compose usage
- Corrects Python script path in Docker configuration

## Changes
- Update `actions/checkout@v3` → `actions/checkout@v4` (Node.js 20 compatibility)
- Replace `docker-compose` → `docker compose` (modern syntax)
- Fix Python path: `python get_count.py` → `python src/get_count.py`

## Test plan
- [ ] Workflow runs without exit code 127 errors
- [ ] Docker container builds and runs successfully
- [ ] Statistics data is collected and logged properly

Fixes #13 #14

🤖 Generated with [Claude Code](https://claude.ai/code)